### PR TITLE
Fix cocoapod warning from duplicate key entry in podspec.

### DIFF
--- a/script/GCAppirater.podspec.erb
+++ b/script/GCAppirater.podspec.erb
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/gamechanger/gcappirater.git", :tag => "<%= version %>" }
   s.source_files = "Pod/Classes/**/*"
   s.frameworks = 'CFNetwork', 'SystemConfiguration'
-  s.license = { :type => 'MIT', :type => 'LICENSE' }
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.requires_arc = true
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
selfie cc @eliran 

Cocoapods was giving a warning was because the key `type` was duplicated and overwritten.